### PR TITLE
Minor bugfixes to improve the user experience

### DIFF
--- a/scripts/create_custom_ubuntu_iso.sh
+++ b/scripts/create_custom_ubuntu_iso.sh
@@ -59,7 +59,9 @@ function set_timeout
 
 function create_iso
 {
-    mkisofs -r -V "Automated Ubuntu Install CD" \
+    isocmd="mkisofs"
+    command -v "$isocmd" >/dev/null 2>&1 || isocmd="genisoimage"
+    $isocmd -r -V "Automated Ubuntu Install CD" \
     -cache-inodes \
     -J -l -b isolinux/isolinux.bin \
     -c isolinux/boot.cat -no-emul-boot \

--- a/scripts/create_customxs_iso.sh
+++ b/scripts/create_customxs_iso.sh
@@ -62,7 +62,9 @@ cp "$TOP_DIR/data/isolinux.cfg" "${ISOROOT}/boot/isolinux/isolinux.cfg"
 
 echo "Create new iso: $TARGET_ISO"
 echo '/boot 1000' > sortlist
-mkisofs -quiet -joliet -joliet-long -r -b boot/isolinux/isolinux.bin \
+isocmd="mkisofs"
+command -v "$isocmd" >/dev/null 2>&1 || isocmd="genisoimage"
+$isocmd -quiet -joliet -joliet-long -r -b boot/isolinux/isolinux.bin \
 -c boot/isolinux/boot.cat -no-emul-boot -boot-load-size 4 \
 -boot-info-table -sort sortlist -V "My Custom XenServer ISO" -o "$TARGET_ISO" "$ISOROOT"
 

--- a/scripts/xs_start_create_vm_with_cdrom.sh
+++ b/scripts/xs_start_create_vm_with_cdrom.sh
@@ -40,6 +40,6 @@ stage "$STAGING_DIR" "$ISO_FILE" customxs.iso
 stage "$STAGING_DIR" "$THIS_DIR/_xs_vm_starter.sh" starter.sh
 
 tar -C "$STAGING_DIR" -chzf - . |
-ssh "root@$XENSERVER" "mkdir vh && cd vh && tar -xzf - && bash starter.sh $NETWORK_NAME $MACHINE_NAME && cd .. && rm -rf vh"
+ssh -o StrictHostKeyChecking=no "root@$XENSERVER" "mkdir -p vh && cd vh && tar -xzf - && bash starter.sh $NETWORK_NAME $MACHINE_NAME && cd .. && rm -rf vh"
 
 rm -rf "$STAGING_DIR"


### PR DESCRIPTION
- Use genisoimage if mkisofs is not availiable.
- Be less prescriptive in xs_start_create_vm_with_cdrom. Don't abort if the vh
  folder exists already
- Use -o StrictHostKeyChecking=no

Signed-off-by: Robert Breker
