### PR TITLE
Move to XenServer 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ hypervisor, you should type:
     scripts/xs_start_create_vm_with_cdrom.sh customxs.iso xshost.somedomain net VMH1
 
 After this, you'll have a virtual hypervisor installed with the name `VMH1`.
-    
+
 On VirtualBox or KVM
 --------------------
 There are simple scripts, which assume, you have `customxs.iso` in your working
@@ -110,7 +110,7 @@ Steps:
 
     $ scripts/create_custom_ubuntu_iso.sh ubuntu-13.04-server-amd64.iso ubuntu_modded.iso data/autoinst.preseed
 
-    $ time kvm -enable-kvm -m 4192 -cdrom ubuntu_modded.iso -vnc :1 -boot d hda 
+    $ time kvm -enable-kvm -m 4096 -cdrom ubuntu_modded.iso -vnc :1 -boot d hda
     real5m7.610s
     user2m38.022s
     sys2m13.128s

--- a/create_virtual_hypervisor.sh
+++ b/create_virtual_hypervisor.sh
@@ -15,6 +15,8 @@ scripts/virtualbox_detach_customxs_iso.sh
 scripts/kvm_create_harddisk.sh
 
 scripts/kvm_start_vm_with_cdrom.sh "customxs.iso"
+echo "First boot..."
+scripts/kvm_start_vm.sh
 ;;
   * )
 echo "ERROR: Please specify hypervisor to use (kvm or virtualbox)"
@@ -23,4 +25,4 @@ exit 1
 
 esac
 
-echo "XCP Setup completed"
+echo "XenServer Setup completed"

--- a/data/firstboot.sh
+++ b/data/firstboot.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+systemctl disable postinstall.service
 halt -p

--- a/data/isolinux.cfg
+++ b/data/isolinux.cfg
@@ -7,19 +7,19 @@ F2 pg_help
 
 LABEL install
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=max:752M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=file:///answerfile.xml install --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=1024M,max:1024M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 atexit=poweroff answerfile=file:///answerfile.xml install --- /install.img
 LABEL no-serial
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=752M,max:752M console=vga --- /boot/vmlinuz console=tty0 --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=1024M,max:1024M console=vga --- /boot/vmlinuz console=tty0 --- /install.img
 LABEL safe
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=max:752M nosmp noreboot noirqbalance acpi=off noapic com1=115200,8n1 console=com1,vga vga=keep --- /boot/vmlinuz nousb xencons=hvc console=hvc0 console=tty0 --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=1024M,max:1024M nosmp noreboot noirqbalance no-mce no-bootscrub no-numa no-hap no-mmcfg iommu=off max_cstate=0 nmi=ignore allow_unsafe com1=115200,8n1 console=com1,vga vga=keep --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 --- /install.img
 LABEL multipath
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=max:752M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 device_mapper_multipath=enabled --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=1024M,max:1024M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 device_mapper_multipath=enabled --- /install.img
 LABEL shell
 	KERNEL mboot.c32
-	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=max:752M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 bash-shell --- /install.img
+	APPEND /boot/xen.gz dom0_max_vcpus=1-2 dom0_mem=1024M,max:1024M com1=115200,8n1 console=com1,vga --- /boot/vmlinuz xencons=hvc console=hvc0 console=tty0 bash-shell --- /install.img
 
 LABEL memtest
 	KERNEL memtest

--- a/data/postinst.sh
+++ b/data/postinst.sh
@@ -1,4 +1,17 @@
 #!/bin/sh
-touch $1/tmp/postinst.sh.executed
-cp /firstboot.sh $1/etc/firstboot.d/95-firstboot
-chmod 777 $1/etc/firstboot.d/95-firstboot
+touch $1/root/post-executed
+cp /firstboot.sh $1/root/first-boot-script.sh
+chmod 777 $1/root/first-boot-script.sh
+touch $1/etc/systemd/system/postinstall.service
+chmod 777 $1/etc/systemd/system/postinstall.service
+cat > $1/etc/systemd/system/postinstall.service <<EOF
+[Unit]
+After=xapi.service
+
+[Service]
+ExecStart=/root/first-boot-script.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+ln -s /etc/systemd/system/postinstall.service $1/etc/systemd/system/multi-user.target.wants/postinstall.service

--- a/scripts/_xs_vm_starter.sh
+++ b/scripts/_xs_vm_starter.sh
@@ -49,15 +49,11 @@ xe vm-param-set uuid=$VXS VCPUs-max=$CPUCOUNT
 xe vm-param-set uuid=$VXS VCPUs-at-startup=$CPUCOUNT
 
 # First-time start
-xe vm-param-set uuid=$VXS actions-after-reboot=Destroy
 xe vm-start uuid=$VXS
 xe vm-param-set uuid=$VXS name-label="$MACHINE_NAME - booted from iso (Step 2 of 3)"
 
 # Wait for shut
 while ! xe vm-param-get param-name=power-state uuid=$VXS | grep -q halted; do sleep 1; done
-
-# Set back normal behavior
-xe vm-param-set uuid=$VXS actions-after-reboot=Restart
 
 # Start again, so install completes
 xe vm-start uuid=$VXS

--- a/scripts/create_customxs_iso.sh
+++ b/scripts/create_customxs_iso.sh
@@ -43,16 +43,16 @@ INITRDROOT=`mktemp -d`
 
 echo "Remastering $ISOROOT/install.img"
 cat << FAKEROOT | fakeroot bash
+set -eu
 cd "$INITRDROOT"
-zcat "$ISOROOT/install.img" | cpio -idum --quiet
-
+bzip2 -dc "$ISOROOT/install.img" | cpio -idum --quiet
 # Do the remastering
 cat "$ANSWERFILE" > "./answerfile.xml"
 cp "$TOP_DIR/data/postinst.sh" ./
 cp "$TOP_DIR/data/firstboot.sh" ./
 
 # Re-pack initrd
-find . -print | cpio -o --quiet -H newc | xz --format=lzma > "${ISOROOT}/install.img"
+find . | cpio --create --format=newc | bzip2 -zc -9 > "${ISOROOT}/install.img"
 FAKEROOT
 
 echo "Removing $INITRDROOT"

--- a/scripts/kvm_create_harddisk.sh
+++ b/scripts/kvm_create_harddisk.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -eux
 
-qemu-img create -f qcow2 stuff.qcow 20G
+qemu-img create -f qcow2 stuff.qcow 50G

--- a/scripts/kvm_start_vm_with_cdrom.sh
+++ b/scripts/kvm_start_vm_with_cdrom.sh
@@ -16,4 +16,4 @@ exit 1
 
 ISOFILE="${1-$(print_usage_and_quit)}"
 
-kvm -enable-kvm -m 4192 -cdrom "$ISOFILE" -vnc :1 -boot d stuff.qcow
+kvm -enable-kvm -m 4096 -cdrom "$ISOFILE" -vnc :1 -boot d stuff.qcow


### PR DESCRIPTION
XenServer 7 needs more memory for dom0, and also different boot
parameters. Also added the atexit=poweroff so the installer will power
off the VM after the installation. KVM and XenServer Scripts adjusted
accordingly. Also updated postinstall script not to rely on firstboot
but be a standalone systemd unit. Also adjusted the remaster script to
use bzip2 compression.